### PR TITLE
[GET issues/index] Filtering issues with url params

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -50,14 +50,16 @@ class IssuesController < ApplicationController
       .reject(&:empty?)
       .map(&:to_i)
 
+    # iterate over currently assigned users and
+    # delete user ids who does not appear in the updated user set
     remaining_user_ids = @issue.assignees.map do |assignee|
       unless new_user_ids.include?(assignee.id)
-        # remove redundant assignees
         @issue.assignees.delete(assignee)
         next
       end
       assignee.id
     end
+    # add newly assigned users without removing overlapping ones
     @issue.assignees << User.find(new_user_ids - remaining_user_ids)
 
     respond_to do |format|

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -83,34 +83,58 @@ class IssuesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_issue
       @issue = Issue.find(params[:id])
     end
 
+    # required params for update / create
     def issue_params
       params
         .require(:issue)
         .permit(:title, :description, :issue_status_id, :issue_priority_id, :discipline_id, :assignee_ids => [])
     end
 
-    #optional params
+    # optional params for sorting / filtering
     def filter_params
-      params.fetch(:sort, {}).permit(:type, :criteria, :value)
+      params
+        .permit(:assignee => [:id], discipline: [:id], :status => [:id], priority: [ :value, :type ])
     end
 
     def filtered_issues
-      return Issue.all unless filter_params[:type] == 'assignee'
-      filter(Issue.all, filter_params[:type])
+      filter(Issue.all, filter_params.keys)
     end
 
-    def filter(queryset, filter_type)
-      queryset.select do |issue|
-        case filter_type
+    # recursively percolate/select based on filtering params
+    def filter(queryset, filter_types)
+      selector = filter_types.pop
+
+      return queryset unless selector
+      filtered_queryset = queryset.select do |issue|
+        case selector
         when 'assignee'
-          value = filter_params[:value].to_i
-          issue.assignees.map(&:id).include?(value)
+          id = filter_params[selector][:id].to_i
+          issue.assignees.map(&:id).include?(id)
+        when 'status'
+          unless issue.status.nil?
+            id = filter_params[selector][:id].to_i
+            issue.status.id == id
+          end
+        when 'discipline'
+          unless issue.discipline.nil?
+            id = filter_params[selector][:id].to_i
+            issue.discipline.id == id
+          end
+        when 'priority'
+          unless issue.priority.nil?
+            value = filter_params[selector][:value].to_i
+            if filter_params.dig(selector, :type) == 'exact'
+              issue.priority.value == value
+            else
+              issue.priority.value < value.succ
+            end
+          end
         end
       end
+      filter(filtered_queryset, filter_types)
     end
 end

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -34,7 +34,7 @@
         <div class="divTableCell">
           <%= link_to(
                   issue.status.label,
-                  issues_path(status: { id: issue.status.id }, **{}) # **{ "assignee"=>{ "value"=>"3" }}
+                  issues_path(status: { id: issue.status.id }, **{})
               ) if issue.status %>
         </div>
         <div class="divTableCell">

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -22,19 +22,19 @@
         <div class="divTableCell">
           <%= link_to(
                   issue.discipline.label,
-                  issues_path(discipline: { id: issue.discipline.id }, **{})
+                  issues_path(discipline: { id: issue.discipline.id }, **params.as_json)
               ) if issue.discipline %>
         </div>
         <div class="divTableCell">
           <%= link_to(
                   issue.priority.label,
-                  issues_path(priority: { value: issue.priority.value }, **{})
+                  issues_path(priority: { value: issue.priority.value }, **params.as_json)
               ) if issue.priority %>
         </div>
         <div class="divTableCell">
           <%= link_to(
                   issue.status.label,
-                  issues_path(status: { id: issue.status.id }, **{})
+                  issues_path(status: { id: issue.status.id }, **params.as_json)
               ) if issue.status %>
         </div>
         <div class="divTableCell">
@@ -44,7 +44,7 @@
             <% issue.assignees.each do |assignee| %>
               <%= link_to(
                       assignee.name,
-                      issues_path(assignee: { id: assignee.id }, **{})
+                      issues_path(assignee: { id: assignee.id }, **params.as_json)
                   ) %>
             <% end %>
           <% end %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -20,20 +20,32 @@
           <%= link_to issue.title, issue %>
         </div>
         <div class="divTableCell">
-          <%= link_to(issue.discipline.label, issues_path) if issue.discipline %>
+          <%= link_to(
+                  issue.discipline.label,
+                  issues_path(discipline: { id: issue.discipline.id }, **{})
+              ) if issue.discipline %>
         </div>
         <div class="divTableCell">
-          <%= link_to(issue.priority.label, issues_path) if issue.priority %>
+          <%= link_to(
+                  issue.priority.label,
+                  issues_path(priority: { value: issue.priority.value }, **{})
+              ) if issue.priority %>
         </div>
         <div class="divTableCell">
-          <%= link_to(issue.status.label, issues_path) if issue.status %>
+          <%= link_to(
+                  issue.status.label,
+                  issues_path(status: { id: issue.status.id }, **{}) # **{ "assignee"=>{ "value"=>"3" }}
+              ) if issue.status %>
         </div>
         <div class="divTableCell">
           <% if issue.assignees.empty? %>
             <em>Unassigned</em>
           <% else %>
             <% issue.assignees.each do |assignee| %>
-              <%= link_to(assignee.name, issues_path(sort: { type: 'assignee', criteria: 'exact', value: assignee.id })) %>
+              <%= link_to(
+                      assignee.name,
+                      issues_path(assignee: { id: assignee.id }, **{})
+                  ) %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,22 +10,23 @@
   </head>
 
   <body>
-  <header class="component_header">
-    <div class="component-slideout-panel">
-    <nav class="component-header__main-nav" aria-label="Main Menu">
-      <div class="logo-nav-group">
-        <a class="component-logo component-logo--theme-dark" href="https://unity.com/" aria-label="Home">
-          <svg id="logo_svg__Logo" xmlns="http://www.w3.org/2000/svg" height="32" x="0" y="0" viewBox="0 0 130.5 48" xml:space="preserve">
-            <style>.logo_svg__st0{fill:#fff}.logo_svg__st1{fill:#ccc}</style>
-            <path class="logo_svg__st0" d="M53.7 26.1V12.5h5.7v13.8c0 2.3 1.2 3.8 4 3.8 2.6 0 3.9-1.6 3.9-3.9V12.5H73v13.6c0 5.3-3.2 8.5-9.6 8.5-6.5.1-9.7-3.1-9.7-8.5zm21.9-8.4h5.1V20h.1c1.2-1.8 2.8-2.7 5.1-2.7 3.6 0 5.7 2.6 5.7 6.3v10.7h-5.3v-9.7c0-1.7-.9-2.9-2.6-2.9-1.7 0-2.9 1.5-2.9 3.5v9.1h-5.3V17.7zm18.7-6.5h5.3v4.3h-5.3v-4.3zm0 6.5h5.3v16.5h-5.3V17.7zm9.4 12.2V22h-2.2v-4.3h2.2v-5.2h5.1v5.2h3V22h-3v6.8c0 1.3.7 1.6 1.8 1.6h1.2v3.8c-.5.1-1.5.3-2.9.3-3 0-5.2-1-5.2-4.6zm11.4 5.7h1.8c1.5 0 2.2-.6 2.2-1.7 0-.7-.3-1.7-1-3.4l-4.9-12.7h5.5l2.2 7c.5 1.6 1 3.8 1 3.8h.1s.5-2.2 1-3.8l2.2-7h5.3l-5.7 16.7c-1.3 3.9-2.9 5.2-6.2 5.2h-3.4l-.1-4.1z"></path>
-            <path class="logo_svg__st1" d="M42.5 33.6V11.2L23.1 0v8.6l7.6 4.4c.3.2.3.6 0 .7l-9 5.2c-.3.2-.6.1-.8 0l-9-5.2c-.3-.1-.3-.6 0-.7l7.6-4.4V0L0 11.2v22.4-.1.1l7.4-4.3v-8.8c0-.3.4-.5.6-.4l9 5.2c.3.2.4.4.4.7v10.4c0 .3-.4.5-.6.4l-7.6-4.4-7.4 4.3L21.2 48l19.4-11.2-7.4-4.3-7.6 4.4c-.3.2-.6 0-.6-.4V26.1c0-.3.2-.6.4-.7l9-5.2c.3-.2.6 0 .6.4v8.8l7.5 4.2z"></path>
-            <path d="M21.2 48l19.4-11.2-7.4-4.3-7.6 4.4c-.3.2-.6 0-.6-.4V26.1c0-.3.2-.6.4-.7l9-5.2c.3-.2.6 0 .6.4v8.8l7.4 4.3V11.2L21.2 23.5V48z" fill="#a6a6a6"></path>
-            <path class="logo_svg__st0" d="M23.1 0v8.6l7.6 4.4c.3.2.3.6 0 .7l-9 5.2c-.3.2-.6.1-.8 0l-9-5.2c-.3-.1-.3-.6 0-.7l7.6-4.4V0L0 11.2l21.2 12.3 21.2-12.3L23.1 0z"></path>
-            <path class="logo_svg__st1" d="M16.9 36.9l-7.6-4.4-7.4 4.3L21.3 48V23.5L0 11.2v22.4-.1.1l7.4-4.3v-8.8c0-.3.4-.5.6-.4l9 5.2c.3.2.4.4.4.7v10.4c.1.4-.2.7-.5.5z"></path>
-          </svg>
-        </a>
-      </div></nav>
-    </div></header>
+    <header class="component_header">
+      <div class="component-slideout-panel">
+      <nav class="component-header__main-nav" aria-label="Main Menu">
+        <div class="logo-nav-group">
+          <a class="component-logo component-logo--theme-dark" href="https://unity.com/" aria-label="Home">
+            <svg id="logo_svg__Logo" xmlns="http://www.w3.org/2000/svg" height="32" x="0" y="0" viewBox="0 0 130.5 48" xml:space="preserve">
+              <style>.logo_svg__st0{fill:#fff}.logo_svg__st1{fill:#ccc}</style>
+              <path class="logo_svg__st0" d="M53.7 26.1V12.5h5.7v13.8c0 2.3 1.2 3.8 4 3.8 2.6 0 3.9-1.6 3.9-3.9V12.5H73v13.6c0 5.3-3.2 8.5-9.6 8.5-6.5.1-9.7-3.1-9.7-8.5zm21.9-8.4h5.1V20h.1c1.2-1.8 2.8-2.7 5.1-2.7 3.6 0 5.7 2.6 5.7 6.3v10.7h-5.3v-9.7c0-1.7-.9-2.9-2.6-2.9-1.7 0-2.9 1.5-2.9 3.5v9.1h-5.3V17.7zm18.7-6.5h5.3v4.3h-5.3v-4.3zm0 6.5h5.3v16.5h-5.3V17.7zm9.4 12.2V22h-2.2v-4.3h2.2v-5.2h5.1v5.2h3V22h-3v6.8c0 1.3.7 1.6 1.8 1.6h1.2v3.8c-.5.1-1.5.3-2.9.3-3 0-5.2-1-5.2-4.6zm11.4 5.7h1.8c1.5 0 2.2-.6 2.2-1.7 0-.7-.3-1.7-1-3.4l-4.9-12.7h5.5l2.2 7c.5 1.6 1 3.8 1 3.8h.1s.5-2.2 1-3.8l2.2-7h5.3l-5.7 16.7c-1.3 3.9-2.9 5.2-6.2 5.2h-3.4l-.1-4.1z"></path>
+              <path class="logo_svg__st1" d="M42.5 33.6V11.2L23.1 0v8.6l7.6 4.4c.3.2.3.6 0 .7l-9 5.2c-.3.2-.6.1-.8 0l-9-5.2c-.3-.1-.3-.6 0-.7l7.6-4.4V0L0 11.2v22.4-.1.1l7.4-4.3v-8.8c0-.3.4-.5.6-.4l9 5.2c.3.2.4.4.4.7v10.4c0 .3-.4.5-.6.4l-7.6-4.4-7.4 4.3L21.2 48l19.4-11.2-7.4-4.3-7.6 4.4c-.3.2-.6 0-.6-.4V26.1c0-.3.2-.6.4-.7l9-5.2c.3-.2.6 0 .6.4v8.8l7.5 4.2z"></path>
+              <path d="M21.2 48l19.4-11.2-7.4-4.3-7.6 4.4c-.3.2-.6 0-.6-.4V26.1c0-.3.2-.6.4-.7l9-5.2c.3-.2.6 0 .6.4v8.8l7.4 4.3V11.2L21.2 23.5V48z" fill="#a6a6a6"></path>
+              <path class="logo_svg__st0" d="M23.1 0v8.6l7.6 4.4c.3.2.3.6 0 .7l-9 5.2c-.3.2-.6.1-.8 0l-9-5.2c-.3-.1-.3-.6 0-.7l7.6-4.4V0L0 11.2l21.2 12.3 21.2-12.3L23.1 0z"></path>
+              <path class="logo_svg__st1" d="M16.9 36.9l-7.6-4.4-7.4 4.3L21.3 48V23.5L0 11.2v22.4-.1.1l7.4-4.3v-8.8c0-.3.4-.5.6-.4l9 5.2c.3.2.4.4.4.7v10.4c.1.4-.2.7-.5.5z"></path>
+            </svg>
+          </a>
+        </div></nav>
+      </div>
+    </header>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,3 @@
 Rails.application.routes.draw do
   resources :issues
 end
-
-
-# require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
-#
-# patcher = Module.new do
-#   extend ActiveSupport::Concern
-#
-#   included do
-#     hook_for :resource_route, required: true
-#   end
-# end
-#
-# Rails::Generators::ScaffoldControllerGenerator.send :include, patcher

--- a/spec/requests/issue_spec.rb
+++ b/spec/requests/issue_spec.rb
@@ -8,6 +8,11 @@ describe IssuesController, :type => :controller do
     let(:issue1) { Issue.new(title: "AAA Title", issue_priority_id: priority.id, issue_status_id: status.id, discipline_id: discipline.id) }
     let(:issue2) { Issue.new(title: "BBB Title", issue_priority_id: priority.id, issue_status_id: status.id, discipline_id: discipline.id) }
 
+    before do
+      issue1.save
+      issue2.save
+    end
+
     it 'should fetch index' do
       get :index, :format => 'json'
       expect(response.content_type).to eq "application/json"
@@ -15,10 +20,8 @@ describe IssuesController, :type => :controller do
       expect(json_response.map { |issue| issue.fetch('title') }.uniq.count).to eq Issue.all.count
     end
 
-    it 'should return records selectively based on search params (with discipline)' do
-      issue1.save
+    it 'should return records selectively, based on proper search params' do
       issue2.assignees << User.last
-      issue2.save
 
       get :index, format: 'json', params: {
         assignee: { 'id' => User.last.id.inspect },
@@ -30,28 +33,28 @@ describe IssuesController, :type => :controller do
       expect(json_response.first['title']).to eq issue2.title
     end
 
-    it 'should return records selectively based on search params (user is unassigned)' do
-      issue1.save
-      issue2.save
-
+    it 'should not return records, based on faulty search params: unassigned user' do
       get :index, format: 'json', params: {
         assignee: { 'id' => User.last.id.inspect },
         status:   { id: status.id },
         priority: { value: priority.value, type: 'exact' }
       }
-      expect(json_response.count).to eq 0
+      expect(json_response).to eq []
     end
 
-    it 'should return records selectively based on search params (only on priority)' do
-      issue1.save
-      issue2.save
-
-      # default behaviour: requested priority  and below (down to highest importance)
+    # default behaviour:
+    it 'should return records selectively, based on search params: priority down to highest importance' do
       get :index, format: 'json', params: { priority: { value: 1 } }
-
       expect(json_response).not_to be_empty
       priority_ids = json_response.map {|i| i['issue_priority_id'] }.uniq
       expect(IssuePriority.find(priority_ids).map(&:label)).to eq IssuePriority.where(value: (0..1).to_a).map &:label
+    end
+
+    it 'should return records selectively, based on search params: exact priority' do
+      get :index, format: 'json', params: { priority: { value: 1, type: 'exact' } }
+      expect(json_response.count).to be > 1
+      priority_ids = json_response.map {|i| i['issue_priority_id'] }.uniq
+      expect(priority_ids.count).to eq 1
     end
   end
 end

--- a/spec/requests/issue_spec.rb
+++ b/spec/requests/issue_spec.rb
@@ -2,11 +2,56 @@ require 'rails_helper'
 
 describe IssuesController, :type => :controller do
   describe '#index' do
+    let(:priority) { IssuePriority.find(2) }
+    let(:status) { IssueStatus.find(3) }
+    let(:discipline) { Discipline.find(2) }
+    let(:issue1) { Issue.new(title: "AAA Title", issue_priority_id: priority.id, issue_status_id: status.id, discipline_id: discipline.id) }
+    let(:issue2) { Issue.new(title: "BBB Title", issue_priority_id: priority.id, issue_status_id: status.id, discipline_id: discipline.id) }
+
     it 'should fetch index' do
       get :index, :format => 'json'
       expect(response.content_type).to eq "application/json"
       expect(json_response.count).to eq Issue.all.count
       expect(json_response.map { |issue| issue.fetch('title') }.uniq.count).to eq Issue.all.count
+    end
+
+    it 'should return records selectively based on search params (with discipline)' do
+      issue1.save
+      issue2.assignees << User.last
+      issue2.save
+
+      get :index, format: 'json', params: {
+        assignee: { 'id' => User.last.id.inspect },
+        status:   { id: status.id },
+        priority: { value: priority.value, type: 'exact' }
+      }
+      expect(json_response.count).to eq 1
+      expect(json_response.first['id']).to eq issue2.id
+      expect(json_response.first['title']).to eq issue2.title
+    end
+
+    it 'should return records selectively based on search params (user is unassigned)' do
+      issue1.save
+      issue2.save
+
+      get :index, format: 'json', params: {
+        assignee: { 'id' => User.last.id.inspect },
+        status:   { id: status.id },
+        priority: { value: priority.value, type: 'exact' }
+      }
+      expect(json_response.count).to eq 0
+    end
+
+    it 'should return records selectively based on search params (only on priority)' do
+      issue1.save
+      issue2.save
+
+      # default behaviour: requested priority  and below (down to highest importance)
+      get :index, format: 'json', params: { priority: { value: 1 } }
+
+      expect(json_response).not_to be_empty
+      priority_ids = json_response.map {|i| i['issue_priority_id'] }.uniq
+      expect(IssuePriority.find(priority_ids).map(&:label)).to eq IssuePriority.where(value: (0..1).to_a).map &:label
     end
   end
 end


### PR DESCRIPTION
This effort paves the way for `GET issues/index` to start accepting url query params and return results based on criteria match.

Allowed issue filtering fields are:
 - discipline
 - priority (exact and [con]descending lookup)
 - status
 - assigned users