### PR TITLE
Prevent issue assignation to already assigned users

### DIFF
--- a/db/migrate/20220226040845_add_issues_to_users.rb
+++ b/db/migrate/20220226040845_add_issues_to_users.rb
@@ -10,9 +10,24 @@ class AddIssuesToUsers < ActiveRecord::Migration[5.2]
     # | issue_id | bigint(20) | YES  | MUL | NULL    |                |
     # | user_id  | bigint(20) | YES  | MUL | NULL    |                |
     # +----------+------------+------+-----+---------+----------------+
+    #
+    # SHOW INDEX FROM issues_users;
+    # +--------------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
+    # | Table        | Non_unique | Key_name                       | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+    # +--------------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
+    # | issues_users |          0 | PRIMARY                        |            1 | id          | A         |           7 |     NULL | NULL   |      | BTREE      |         |               |
+    # | issues_users |          0 | index_on_issue_id_and_user_id  |            1 | issue_id    | A         |           5 |     NULL | NULL   | YES  | BTREE      |         |               |
+    # | issues_users |          0 | index_on_issue_id_and_user_id  |            2 | user_id     | A         |           7 |     NULL | NULL   | YES  | BTREE      |         |               |
+    # | issues_users |          1 | index_issues_users_on_issue_id |            1 | issue_id    | A         |           6 |     NULL | NULL   | YES  | BTREE      |         |               |
+    # | issues_users |          1 | index_issues_users_on_user_id  |            1 | user_id     | A         |           3 |     NULL | NULL   | YES  | BTREE      |         |               |
+    # +--------------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
     create_table :issues_users do |t|
       t.belongs_to :issue, index: true
       t.belongs_to :user,  index: true
     end
+    execute(%Q{
+      ALTER TABLE `issues_users`
+        ADD UNIQUE KEY `index_on_issue_id_and_user_id` (`issue_id`, `user_id`)
+    })
   end
 end


### PR DESCRIPTION
### Overview 
Users can be assigned to an issue _only once_.

### Solution: 
Add a single _unique_ [key](https://github.com/Kartoshka548/yaits/pull/10/files#diff-967f1c16ceaf5aa59e53f815b5400951f8f0e81acf313e5161e7af66d60fb83dR30) for both columns in the `issues_users` "through" table: `issue_id` & `user_id` 

### Expected behaviour: 
```
Issue.last.assignees << Issue.last.assignees.first
[...]
ActiveRecord::RecordNotUnique (Mysql2::Error: Duplicate entry [...])
```